### PR TITLE
Add developer guide and code of conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,43 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies within all community spaces and also applies when an individual is officially representing the community in public spaces.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at the contact information provided in the repository's README.
+
+All complaints will be reviewed and investigated promptly and fairly.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org) version 2.1.

--- a/README.md
+++ b/README.md
@@ -25,3 +25,10 @@
 * 私はPM兼データサイエンティストとして全体統括、MVP要件検討、レコメンドアルゴリズム構築を担当
 * エンジニアの方にはチャットアプリ開発をお願いしたいと考えております。
 
+
+---
+
+## Project Resources
+
+* [Developer Guide](docs/developer_guide.md)
+* [Code of Conduct](CODE_OF_CONDUCT.md)

--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -1,0 +1,40 @@
+# Developer Guide
+
+This document outlines how to contribute to the **ai_travel** project.
+
+## Requirements
+
+The repository currently provides documentation and planning material for a travel concierge application. When code becomes available, we expect a standard Python development environment.
+
+1. [Python](https://www.python.org/) 3.11 or later
+2. [Poetry](https://python-poetry.org/) for dependency management
+
+## Getting Started
+
+1. Clone the repository:
+
+```bash
+git clone <repository-url>
+cd ai_travel
+```
+
+2. Install dependencies:
+
+```bash
+poetry install
+```
+
+3. Run tests:
+
+```bash
+poetry run pytest
+```
+
+## Contributing Workflow
+
+1. Create a new branch for your feature or bug fix.
+2. Write tests for any new behavior.
+3. Ensure `pytest` passes before submitting a pull request.
+4. Keep pull requests focused and provide a clear description of the change.
+
+We welcome improvements and suggestions! Feel free to open issues for discussion before you start implementing a larger feature.


### PR DESCRIPTION
## Summary
- add a Contributor Covenant Code of Conduct
- add a developer guide with setup and contribution instructions
- link to these docs from the README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683addb5133c83328d2bc916bc25d90b