### PR TITLE
Implement basic CLI for travel planning MVP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+*.pyc
+.poetry
+.env
+.pytest_cache/

--- a/README.md
+++ b/README.md
@@ -32,3 +32,19 @@
 
 * [Developer Guide](docs/developer_guide.md)
 * [Code of Conduct](CODE_OF_CONDUCT.md)
+
+## Running the CLI
+
+A simple command line interface is provided for experimenting with the MVP features.
+
+```
+python -m ai_travel.main
+```
+
+## Running Tests
+
+Use pytest with the repository root on `PYTHONPATH`:
+
+```
+PYTHONPATH=. pytest -q
+```

--- a/ai_travel/main.py
+++ b/ai_travel/main.py
@@ -1,0 +1,51 @@
+from typing import List
+
+from .quick_suggest import suggest_plans
+from .planning import collect_planning_info, plan_trip, PlanningInfo
+
+
+def show_suggestions() -> None:
+    print("== クイックサジェスト ==")
+    tag = input("行き先イメージタグ (温泉/ビーチ/都市観光): ")
+    style = input("好きな旅行スタイル (のんびり/アクティブ/グルメ/歴史巡り): ")
+    plans = suggest_plans(tag, style)
+    if not plans:
+        print("該当するプランが見つかりませんでした。")
+        return
+    for idx, p in enumerate(plans, 1):
+        print(f"[{idx}] {p['destination']} {p['days']}日 {p['budget']}")
+    choice = input("このプランを詳しく詰めますか？ (y/n): ")
+    if choice.lower().startswith('y'):
+        info = collect_planning_info()
+        results = plan_trip(info)
+        print_results(results)
+
+
+def print_results(results: List[dict]) -> None:
+    print("\n-- 予約候補一覧 --")
+    for r in results:
+        for k, v in r.items():
+            print(f"{k}: {v}")
+        print("---")
+
+
+def main() -> None:
+    while True:
+        print("\n1) クイックサジェスト")
+        print("2) じっくりプランニング")
+        print("0) 終了")
+        choice = input("選択してください: ")
+        if choice == '1':
+            show_suggestions()
+        elif choice == '2':
+            info = collect_planning_info()
+            results = plan_trip(info)
+            print_results(results)
+        elif choice == '0':
+            break
+        else:
+            print("無効な選択です。")
+
+
+if __name__ == "__main__":
+    main()

--- a/ai_travel/mock_api.py
+++ b/ai_travel/mock_api.py
@@ -1,0 +1,24 @@
+from typing import List, Dict
+
+from .types import PlanningInfo
+
+# This is a mock function to simulate searching available travel packages.
+# In a real application, this would call external APIs.
+
+def search_available_packages(info: PlanningInfo) -> List[Dict[str, str]]:
+    # For simplicity, return a static list using some of the provided info.
+    base_package = {
+        "destination": "沖縄",
+        "price": info.budget_range,
+        "dates": f"{info.start_date} - {info.end_date}",
+        "people": f"大人{info.adults}名 子ども{info.children}名",
+    }
+    # Add details if available
+    if info.lodging_type:
+        base_package["lodging_type"] = info.lodging_type
+    if info.transportation:
+        base_package["transportation"] = info.transportation
+    if info.activities:
+        base_package["activities"] = ",".join(info.activities)
+
+    return [base_package]

--- a/ai_travel/planning.py
+++ b/ai_travel/planning.py
@@ -1,0 +1,38 @@
+from typing import List, Optional, Dict
+
+from .types import PlanningInfo
+from .mock_api import search_available_packages
+
+
+def prompt_optional(prompt: str) -> Optional[str]:
+    value = input(f"{prompt} (Enter to skip): ")
+    return value or None
+
+
+def collect_planning_info() -> PlanningInfo:
+    print("== 詳細プランニング ==")
+    budget = input("予算レンジ（例：1人あたり3-5万円）: ")
+    start = input("チェックイン日 (YYYY-MM-DD): ")
+    end = input("チェックアウト日 (YYYY-MM-DD): ")
+    adults = int(input("大人の人数: "))
+    children = int(input("子どもの人数 (いなければ0): "))
+
+    lodging = prompt_optional("宿タイプ (ホテル/旅館/民泊など)")
+    transport = prompt_optional("移動手段 (飛行機/新幹線/レンタカーなど)")
+    act = prompt_optional("興味のあるアクティビティ (カンマ区切り)")
+    activities = act.split(',') if act else []
+
+    return PlanningInfo(
+        budget_range=budget,
+        start_date=start,
+        end_date=end,
+        adults=adults,
+        children=children,
+        lodging_type=lodging,
+        transportation=transport,
+        activities=activities,
+    )
+
+
+def plan_trip(info: PlanningInfo) -> List[Dict[str, str]]:
+    return search_available_packages(info)

--- a/ai_travel/quick_suggest.py
+++ b/ai_travel/quick_suggest.py
@@ -1,0 +1,49 @@
+from typing import List, Dict
+
+# Static table of recommended plans
+PLANS = [
+    {
+        "destination": "箱根",
+        "tag": "温泉",
+        "style": "のんびり",
+        "days": 2,
+        "budget": "3-5万円",
+    },
+    {
+        "destination": "熱海",
+        "tag": "ビーチ",
+        "style": "グルメ",
+        "days": 2,
+        "budget": "3-5万円",
+    },
+    {
+        "destination": "京都",
+        "tag": "都市観光",
+        "style": "歴史巡り",
+        "days": 3,
+        "budget": "5-7万円",
+    },
+    {
+        "destination": "沖縄",
+        "tag": "ビーチ",
+        "style": "アクティブ",
+        "days": 3,
+        "budget": "7-10万円",
+    },
+    {
+        "destination": "札幌",
+        "tag": "都市観光",
+        "style": "グルメ",
+        "days": 3,
+        "budget": "5-7万円",
+    },
+]
+
+
+def suggest_plans(tag: str, style: str, limit: int = 3) -> List[Dict[str, str]]:
+    """Return a list of suggested plans matching the tag and style."""
+    matches = [p for p in PLANS if p["tag"] == tag and p["style"] == style]
+    if not matches:
+        # fallback to plans that match the tag only
+        matches = [p for p in PLANS if p["tag"] == tag]
+    return matches[:limit]

--- a/ai_travel/types.py
+++ b/ai_travel/types.py
@@ -1,0 +1,14 @@
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+
+@dataclass
+class PlanningInfo:
+    budget_range: str
+    start_date: str
+    end_date: str
+    adults: int
+    children: int = 0
+    lodging_type: Optional[str] = None
+    transportation: Optional[str] = None
+    activities: List[str] = field(default_factory=list)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,16 @@
+[tool.poetry]
+name = "ai_travel"
+version = "0.1.0"
+description = "MVP travel planning application"
+authors = ["AI Contributor <ai@example.com>"]
+packages = [{include = "ai_travel"}]
+
+[tool.poetry.dependencies]
+python = "^3.11"
+
+[tool.poetry.dev-dependencies]
+pytest = "^7.4"
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"

--- a/tests/test_mock_api.py
+++ b/tests/test_mock_api.py
@@ -1,0 +1,16 @@
+from ai_travel.mock_api import search_available_packages
+from ai_travel.planning import PlanningInfo
+
+
+def test_search_available_packages_basic():
+    info = PlanningInfo(
+        budget_range="3-5万円",
+        start_date="2023-12-01",
+        end_date="2023-12-03",
+        adults=2,
+        children=0,
+    )
+    results = search_available_packages(info)
+    assert isinstance(results, list)
+    assert results[0]["destination"] == "沖縄"
+    assert results[0]["price"] == "3-5万円"

--- a/tests/test_quick_suggest.py
+++ b/tests/test_quick_suggest.py
@@ -1,0 +1,17 @@
+from ai_travel.quick_suggest import suggest_plans
+
+
+def test_suggest_plans_exact_match():
+    plans = suggest_plans("ビーチ", "アクティブ")
+    assert len(plans) > 0
+    for p in plans:
+        assert p["tag"] == "ビーチ"
+        assert p["style"] == "アクティブ"
+
+
+def test_suggest_plans_fallback():
+    plans = suggest_plans("温泉", "アクティブ")
+    # No plan has 温泉 + アクティブ, fallback should match 温泉 only
+    assert len(plans) > 0
+    for p in plans:
+        assert p["tag"] == "温泉"


### PR DESCRIPTION
## Summary
- create Python package with quick suggestions and detailed planning
- add mock API and command line interface
- document how to run the CLI and tests
- configure poetry and gitignore
- add simple unit tests

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683b0035605c8332889b612940646a1d