### PR TITLE
Add filters and rating to quick suggest

### DIFF
--- a/frontend/src/assets/images/plan_fuji_nature.jpg
+++ b/frontend/src/assets/images/plan_fuji_nature.jpg
@@ -1,0 +1,1 @@
+placeholder

--- a/frontend/src/assets/images/plan_fukuoka_gourmet.jpg
+++ b/frontend/src/assets/images/plan_fukuoka_gourmet.jpg
@@ -1,0 +1,1 @@
+placeholder

--- a/frontend/src/assets/images/plan_hakone_onsen.jpg
+++ b/frontend/src/assets/images/plan_hakone_onsen.jpg
@@ -1,0 +1,1 @@
+placeholder

--- a/frontend/src/assets/images/plan_ishigaki_beach.jpg
+++ b/frontend/src/assets/images/plan_ishigaki_beach.jpg
@@ -1,0 +1,1 @@
+placeholder

--- a/frontend/src/assets/images/plan_kanazawa_gourmet.jpg
+++ b/frontend/src/assets/images/plan_kanazawa_gourmet.jpg
@@ -1,0 +1,1 @@
+placeholder

--- a/frontend/src/assets/images/plan_kusatsu_onsen.jpg
+++ b/frontend/src/assets/images/plan_kusatsu_onsen.jpg
@@ -1,0 +1,1 @@
+placeholder

--- a/frontend/src/assets/images/plan_kyoto_city.jpg
+++ b/frontend/src/assets/images/plan_kyoto_city.jpg
@@ -1,0 +1,1 @@
+placeholder

--- a/frontend/src/assets/images/plan_okinawa_beach.jpg
+++ b/frontend/src/assets/images/plan_okinawa_beach.jpg
@@ -1,0 +1,1 @@
+placeholder

--- a/frontend/src/assets/images/plan_tokyo_city.jpg
+++ b/frontend/src/assets/images/plan_tokyo_city.jpg
@@ -1,0 +1,1 @@
+placeholder

--- a/frontend/src/assets/images/plan_yakushima_nature.jpg
+++ b/frontend/src/assets/images/plan_yakushima_nature.jpg
@@ -1,0 +1,1 @@
+placeholder

--- a/frontend/src/components/PlanCard.tsx
+++ b/frontend/src/components/PlanCard.tsx
@@ -1,6 +1,23 @@
 import React from 'react';
 import { PlanCardData } from '../types/types';
 
+const availabilityMap: Record<
+  PlanCardData['availability'],
+  { label: string; color: string }
+> = {
+  available: { label: '空きあり', color: 'text-green-600' },
+  low: { label: '残りわずか', color: 'text-yellow-600' },
+  sold_out: { label: '満室', color: 'text-red-600' },
+};
+
+function renderStars(rating: number) {
+  const full = Math.floor(rating);
+  const stars = Array.from({ length: 5 }, (_, i) =>
+    i < full ? '★' : '☆',
+  );
+  return stars.join('');
+}
+
 interface Props {
   plan: PlanCardData;
   onLike: () => void;
@@ -10,21 +27,41 @@ interface Props {
 }
 
 export const PlanCard: React.FC<Props> = ({ plan, onLike, onDislike, onFavorite, onViewDetail }) => (
-  <div className="border rounded-2xl shadow-md p-4 hover:shadow-xl hover:-translate-y-1 transition-transform">
-    <img src={plan.thumbnailUrl} alt={plan.title} className="w-full h-40 object-cover rounded-lg" />
+  <div className="border rounded-2xl shadow-md p-4 hover:shadow-xl hover:-translate-y-1 transition-transform bg-white">
+    <img
+      src={plan.thumbnailUrl}
+      alt={plan.title}
+      className="w-full h-40 object-cover rounded-lg"
+    />
     <h3 className="text-lg font-semibold mt-2">{plan.title}</h3>
     <span className="inline-block bg-blue-100 text-blue-800 text-xs px-2 py-1 rounded-full">
       {plan.category}
     </span>
-    <p className="text-sm text-gray-600">予算：¥{plan.budgetRange.min}～¥{plan.budgetRange.max}</p>
+    <p className="text-sm text-gray-600 mt-1">予算：¥{plan.budgetRange.min}～¥{plan.budgetRange.max}</p>
     <p className="text-sm text-gray-600">日数：{plan.duration}／大人{plan.persons.adult}名・子ども{plan.persons.child}名</p>
-    <div className="flex items-center space-x-2 mt-2">
+
+    <div className="flex items-center text-sm mt-1">
+      <span className={`mr-1 ${availabilityMap[plan.availability].color}`}>●</span>
+      <span className={availabilityMap[plan.availability].color}>{availabilityMap[plan.availability].label}</span>
+    </div>
+
+    <div className="flex items-center text-sm mt-1">
+      <span className="text-yellow-500">{renderStars(plan.rating)}</span>
+      <span className="ml-1 text-gray-500">({plan.reviewCount}件)</span>
+    </div>
+
+    <div className="flex items-center space-x-3 mt-2">
       <button onClick={onLike} className="text-sm">👍 {plan.likeCount}</button>
       <button onClick={onDislike} className="text-sm">👎 {plan.dislikeCount}</button>
       <button onClick={onFavorite} className="text-sm">
         {plan.isFavorite ? '💖' : '🤍'}
       </button>
-      <button onClick={onViewDetail} className="ml-auto bg-blue-600 text-white px-3 py-1 rounded text-sm">詳細を見る</button>
+      <button
+        onClick={onViewDetail}
+        className="ml-auto bg-blue-600 text-white px-3 py-1 rounded text-sm"
+      >
+        詳細を見る
+      </button>
     </div>
   </div>
 );

--- a/frontend/src/components/QuickSuggestPage.tsx
+++ b/frontend/src/components/QuickSuggestPage.tsx
@@ -11,6 +11,12 @@ import { useNavigate } from 'react-router-dom';
 export const QuickSuggestPage: React.FC = () => {
   const [categories, setCategories] = useState<Category[]>([]);
   const [selectedCategory, setSelectedCategory] = useState<string | null>(null);
+  const [budgetMin, setBudgetMin] = useState(10000);
+  const [budgetMax, setBudgetMax] = useState(100000);
+  const [duration, setDuration] = useState('1泊2日');
+  const [adultCount, setAdultCount] = useState(1);
+  const [childCount, setChildCount] = useState(0);
+  const [styles, setStyles] = useState<string[]>([]);
   const { plans, loading, error, fetchPlans } = useFetchPlans();
   const { favorites, toggleFavorite } = useFavorites();
   const navigate = useNavigate();
@@ -23,15 +29,29 @@ export const QuickSuggestPage: React.FC = () => {
     if (!selectedCategory) return;
     const params: FilterParams = {
       category: selectedCategory,
-      budgetMin: 10000,
-      budgetMax: 100000,
-      duration: '1泊2日',
-      adultCount: 2,
-      childCount: 0,
-      styles: [],
+      budgetMin,
+      budgetMax,
+      duration,
+      adultCount,
+      childCount,
+      styles,
     };
     fetchPlans(params);
-  }, [selectedCategory, fetchPlans]);
+  }, [selectedCategory]);
+
+  const handleSearch = () => {
+    if (!selectedCategory) return;
+    const params: FilterParams = {
+      category: selectedCategory,
+      budgetMin,
+      budgetMax,
+      duration,
+      adultCount,
+      childCount,
+      styles,
+    };
+    fetchPlans(params);
+  };
 
   const handleLike = async (id: string) => {
     await interactWithPlan(id, 'like');
@@ -59,6 +79,100 @@ export const QuickSuggestPage: React.FC = () => {
         ))}
       </div>
 
+      {selectedCategory && (
+        <div className="bg-white shadow-md rounded-lg mx-4 p-4">
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+            <div>
+              <label className="block text-sm font-medium">最低予算</label>
+              <input
+                type="number"
+                value={budgetMin}
+                onChange={(e) => setBudgetMin(Number(e.target.value))}
+                className="mt-1 w-full border rounded-md px-2 py-1"
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium">最高予算</label>
+              <input
+                type="number"
+                value={budgetMax}
+                onChange={(e) => setBudgetMax(Number(e.target.value))}
+                className="mt-1 w-full border rounded-md px-2 py-1"
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium">日数</label>
+              <select
+                value={duration}
+                onChange={(e) => setDuration(e.target.value)}
+                className="mt-1 w-full border rounded-md px-2 py-1"
+              >
+                <option value="1泊2日">1泊2日</option>
+                <option value="2泊3日">2泊3日</option>
+                <option value="3泊4日">3泊4日</option>
+                <option value="それ以上">それ以上</option>
+              </select>
+            </div>
+            <div>
+              <label className="block text-sm font-medium">大人</label>
+              <select
+                value={adultCount}
+                onChange={(e) => setAdultCount(Number(e.target.value))}
+                className="mt-1 w-full border rounded-md px-2 py-1"
+              >
+                {[1, 2, 3, 4].map((n) => (
+                  <option key={n} value={n}>{n}名</option>
+                ))}
+              </select>
+            </div>
+            <div>
+              <label className="block text-sm font-medium">子ども</label>
+              <select
+                value={childCount}
+                onChange={(e) => setChildCount(Number(e.target.value))}
+                className="mt-1 w-full border rounded-md px-2 py-1"
+              >
+                {[0, 1, 2].map((n) => (
+                  <option key={n} value={n}>{n}名</option>
+                ))}
+              </select>
+            </div>
+            <div className="md:col-span-3">
+              <p className="text-sm font-medium">旅行スタイル</p>
+              <div className="flex flex-wrap gap-3 mt-1">
+                {['のんびり', 'アクティブ', '家族向け', 'グルメ', '女子旅'].map((s) => (
+                  <label key={s} className="inline-flex items-center">
+                    <input
+                      type="checkbox"
+                      className="form-checkbox"
+                      value={s}
+                      checked={styles.includes(s)}
+                      onChange={(e) => {
+                        const val = e.target.value;
+                        setStyles((prev) =>
+                          prev.includes(val)
+                            ? prev.filter((v) => v !== val)
+                            : [...prev, val],
+                        );
+                      }}
+                    />
+                    <span className="ml-1 text-sm">{s}</span>
+                  </label>
+                ))}
+              </div>
+            </div>
+          </div>
+          <div className="mt-4 text-right">
+            <button
+              onClick={handleSearch}
+              className="bg-blue-600 text-white px-4 py-2 rounded"
+            >
+              検索
+            </button>
+          </div>
+        </div>
+      )}
+
       {loading && <LoadingSpinner />}
       {error && <p className="text-center text-red-500">{error}</p>}
 
@@ -74,6 +188,10 @@ export const QuickSuggestPage: React.FC = () => {
           />
         ))}
       </div>
+
+      {!loading && plans.length === 0 && (
+        <p className="text-center text-gray-500 py-8">該当するプランが見つかりませんでした。</p>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- improve plan cards with availability indicator and rating stars
- add filter form to quick suggest page
- provide placeholder plan images for sample data

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683ba794f3dc833299a4681fbf524f7b