### PR TITLE
Add slider and plan detail endpoints

### DIFF
--- a/frontend/src/pages/detail.tsx
+++ b/frontend/src/pages/detail.tsx
@@ -1,9 +1,39 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import { fetchPlanDetail } from '../services/api';
+import { PlanDetail } from '../types/types';
+import { LoadingSpinner } from '../components/LoadingSpinner';
 
 export default function DetailPage() {
+  const [searchParams] = useSearchParams();
+  const planId = searchParams.get('planId');
+  const [plan, setPlan] = useState<PlanDetail | null>(null);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!planId) return;
+    fetchPlanDetail(planId)
+      .then((data) => setPlan(data))
+      .catch((err) => setError((err as Error).message))
+      .finally(() => setLoading(false));
+  }, [planId]);
+
+  if (!planId) return <p className="p-4">No plan specified.</p>;
+  if (loading) return <LoadingSpinner />;
+  if (error) return <p className="p-4 text-red-500">{error}</p>;
+  if (!plan) return <p className="p-4">Plan not found.</p>;
+
   return (
-    <div className="p-4">
-      <h1 className="text-xl font-bold">Coming Soon!</h1>
+    <div className="p-4 space-y-4">
+      <h1 className="text-2xl font-bold">{plan.title}</h1>
+      <img
+        src={plan.imageUrls[0] || plan.thumbnailUrl}
+        alt={plan.title}
+        className="w-full h-60 object-cover rounded-lg"
+      />
+      <p className="text-lg text-gray-700">{plan.catchphrase}</p>
+      <p className="text-gray-600">{plan.description}</p>
     </div>
   );
 }

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,4 +1,11 @@
-import { Category, PlanCardData, FilterParams, InteractionResponse } from "../types/types";
+import {
+  Category,
+  PlanCardData,
+  PlanDetail,
+  SliderItem,
+  FilterParams,
+  InteractionResponse,
+} from "../types/types";
 
 const BASE_URL = process.env.REACT_APP_API_BASE_URL || "http://localhost:4000/api";
 
@@ -33,6 +40,37 @@ export async function interactWithPlan(
   });
   if (!res.ok) {
     throw new Error("Failed to interact with plan");
+  }
+  return res.json();
+}
+
+export async function fetchSliderItems(): Promise<SliderItem[]> {
+  const res = await fetch(`${BASE_URL}/slider-items`);
+  if (!res.ok) {
+    throw new Error("Failed to fetch slider items");
+  }
+  return res.json();
+}
+
+export async function fetchPlanDetail(planId: string): Promise<PlanDetail> {
+  const res = await fetch(`${BASE_URL}/plans/${planId}`);
+  if (!res.ok) {
+    throw new Error("Failed to fetch plan detail");
+  }
+  return res.json();
+}
+
+export async function postPlanAction(
+  planId: string,
+  actionType: "view" | "like" | "dislike" | "booking"
+): Promise<{ likeCount?: number; dislikeCount?: number }> {
+  const res = await fetch(`${BASE_URL}/plans/${planId}/action`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ actionType, userId: "anonymous" }),
+  });
+  if (!res.ok) {
+    throw new Error("Failed to post plan action");
   }
   return res.json();
 }

--- a/frontend/src/types/types.ts
+++ b/frontend/src/types/types.ts
@@ -26,6 +26,22 @@ export interface PlanCardData {
   dislikeCount: number;
 }
 
+export interface PlanDetail extends PlanCardData {
+  catchphrase: string;
+  description: string;
+  imageUrls: string[];
+  videoUrl?: string;
+  styles: string[];
+}
+
+export interface SliderItem {
+  planId: string;
+  title: string;
+  catchphrase: string;
+  imageUrl: string;
+  videoUrl?: string;
+}
+
 export interface FilterParams {
   category: string;
   budgetMin: number;

--- a/mock-server/index.js
+++ b/mock-server/index.js
@@ -16,10 +16,17 @@ function loadData(file) {
 
 const categories = loadData('staticCategories.json');
 const plans = loadData('staticPlans.json');
+const planDetails = loadData('staticPlanDetails.json');
+const sliderItems = loadData('staticSliderItems.json');
 
 // GET /api/categories
 app.get('/api/categories', (req, res) => {
   res.json(categories);
+});
+
+// GET /api/slider-items
+app.get('/api/slider-items', (req, res) => {
+  res.json(sliderItems);
 });
 
 // POST /api/plans/quick-suggest
@@ -37,6 +44,17 @@ app.post('/api/plans/quick-suggest', (req, res) => {
   });
 
   res.json(filtered);
+});
+
+// GET /api/plans/:planId
+app.get('/api/plans/:planId', (req, res) => {
+  const { planId } = req.params;
+  const plan = plans.find((p) => p.id === planId);
+  if (!plan) {
+    return res.status(404).json({ error: 'Plan not found' });
+  }
+  const detail = planDetails.find((d) => d.id === planId) || {};
+  res.json({ ...plan, ...detail });
 });
 
 // POST /api/plans/:planId/interact
@@ -61,6 +79,22 @@ app.post('/api/plans/:planId/interact', (req, res) => {
     dislikeCount: plan.dislikeCount,
     isFavorite: action === 'favorite' ? true : false,
   });
+});
+
+// POST /api/plans/:planId/action (alias)
+app.post('/api/plans/:planId/action', (req, res) => {
+  const { planId } = req.params;
+  const { actionType } = req.body;
+  const plan = plans.find((p) => p.id === planId);
+  if (!plan) {
+    return res.status(404).json({ error: 'Plan not found' });
+  }
+  if (actionType === 'like') {
+    plan.likeCount += 1;
+  } else if (actionType === 'dislike') {
+    plan.dislikeCount += 1;
+  }
+  res.json({ planId: plan.id, likeCount: plan.likeCount, dislikeCount: plan.dislikeCount });
 });
 
 const PORT = process.env.PORT || 4000;

--- a/mock-server/staticPlanDetails.json
+++ b/mock-server/staticPlanDetails.json
@@ -1,0 +1,23 @@
+[
+  {
+    "id": "plan-001",
+    "imageUrls": ["/assets/images/plan_hakone_onsen.jpg"],
+    "catchphrase": "ふわりと湯気に包まれ、心も体もリフレッシュ",
+    "description": "箱根の自然に抱かれた宿で、温泉と会席料理を堪能する1泊2日の癒しプラン。",
+    "styles": ["のんびり", "リラックス"]
+  },
+  {
+    "id": "plan-003",
+    "imageUrls": ["/assets/images/plan_ishigaki_beach.jpg"],
+    "catchphrase": "エメラルドブルーの波を駆け抜ける冒険が待っている",
+    "description": "石垣島のビーチでマリンスポーツを楽しむアクティブプラン。",
+    "styles": ["アクティブ", "ビーチ"]
+  },
+  {
+    "id": "plan-008",
+    "imageUrls": ["/assets/images/plan_yakushima_nature.jpg"],
+    "catchphrase": "永遠の森が呼んでいる…屋久島で神秘の一歩を",
+    "description": "世界遺産の森をトレッキングしながら大自然を満喫する2泊3日の旅。",
+    "styles": ["自然", "アドベンチャー"]
+  }
+]

--- a/mock-server/staticSliderItems.json
+++ b/mock-server/staticSliderItems.json
@@ -1,0 +1,23 @@
+[
+  {
+    "planId": "plan-008",
+    "title": "屋久島2泊3日ジャングルトレッキングプラン",
+    "catchphrase": "永遠の森が呼んでいる…屋久島で神秘の一歩を",
+    "imageUrl": "/assets/images/plan_yakushima_nature.jpg",
+    "videoUrl": null
+  },
+  {
+    "planId": "plan-003",
+    "title": "石垣島ビーチ1泊2日アクティブプラン",
+    "catchphrase": "エメラルドブルーの波を駆け抜ける冒険が待っている",
+    "imageUrl": "/assets/images/plan_ishigaki_beach.jpg",
+    "videoUrl": null
+  },
+  {
+    "planId": "plan-001",
+    "title": "箱根温泉1泊2日リフレッシュプラン",
+    "catchphrase": "ふわりと湯気に包まれ、心をほどく休日",
+    "imageUrl": "/assets/images/plan_hakone_onsen.jpg",
+    "videoUrl": null
+  }
+]


### PR DESCRIPTION
## Summary
- extend mock server with slider-items and plan detail endpoints
- add datasets for slider items and plan details
- expose new API functions in frontend
- implement PlanDetail page to display fetched plan info

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841a03627c88332aa0efe4486f12089