### PR TITLE
Add advanced quick suggest scoring

### DIFF
--- a/ai_travel/quick_suggest.py
+++ b/ai_travel/quick_suggest.py
@@ -1,4 +1,4 @@
-from typing import List, Dict
+from typing import List, Dict, Optional
 
 # Static table of recommended plans
 PLANS = [
@@ -40,10 +40,42 @@ PLANS = [
 ]
 
 
-def suggest_plans(tag: str, style: str, limit: int = 3) -> List[Dict[str, str]]:
-    """Return a list of suggested plans matching the tag and style."""
-    matches = [p for p in PLANS if p["tag"] == tag and p["style"] == style]
-    if not matches:
-        # fallback to plans that match the tag only
-        matches = [p for p in PLANS if p["tag"] == tag]
-    return matches[:limit]
+def suggest_plans(
+    tag: str,
+    style: str,
+    *,
+    days: Optional[int] = None,
+    budget: Optional[str] = None,
+    limit: int = 3,
+) -> List[Dict[str, str]]:
+    """Return a list of suggested plans ranked by how well they match."""
+
+    # First look for exact matches on tag and style
+    exact = [p for p in PLANS if p["tag"] == tag and p["style"] == style]
+    if exact:
+        return exact[:limit]
+
+    def score(plan: Dict[str, str]) -> int:
+        s = 0
+        if plan["tag"] == tag:
+            s += 2
+        if plan["style"] == style:
+            s += 1
+        if days is not None and plan.get("days") == days:
+            s += 1
+        if budget is not None and plan.get("budget") == budget:
+            s += 1
+        return s
+
+    scored = [(score(p), p) for p in PLANS]
+    scored = [item for item in scored if item[0] > 0]
+
+    tag_matches = [item for item in scored if item[1]["tag"] == tag]
+
+    if tag_matches:
+        scored = tag_matches
+    elif not scored:
+        scored = [(2, p) for p in PLANS if p["tag"] == tag]
+
+    scored.sort(key=lambda x: x[0], reverse=True)
+    return [p for _, p in scored[:limit]]

--- a/tests/test_quick_suggest.py
+++ b/tests/test_quick_suggest.py
@@ -15,3 +15,10 @@ def test_suggest_plans_fallback():
     assert len(plans) > 0
     for p in plans:
         assert p["tag"] == "温泉"
+
+
+def test_suggest_plans_days_and_budget():
+    plans = suggest_plans("ビーチ", "アクティブ", days=3, budget="7-10万円")
+    assert len(plans) > 0
+    # The Okinawa plan is the only one fully matching
+    assert plans[0]["destination"] == "沖縄"


### PR DESCRIPTION
## Summary
- enhance `suggest_plans` to rank results using optional days/budget
- ensure fallback keeps tag matches
- add unit test to cover new scoring features

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68499361a0608332b7804bba6549a4e4